### PR TITLE
3 link go wasm module to frontend xterm interface and move test pattern generation to go

### DIFF
--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -10,7 +10,7 @@ func sendMessageToJS(msgType, payload string) {
 }
 
 // receiveMessageFromJS is a Go function exposed to JS for receiving messages from JS
-func receiveMessageFromJS(this js.Value, args []js.Value) interface{} {
+func receiveMessageFromJS(_ js.Value, args []js.Value) interface{} {
 	if len(args) < 2 {
 		return nil
 	}

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -1,9 +1,59 @@
 package main
 
 import (
-	"fmt"
+	"syscall/js"
 )
 
+// sendMessageToJS sends a message to JS with a type and payload (as string)
+func sendMessageToJS(msgType, payload string) {
+	js.Global().Call("retrojs_receiveFromGo", msgType, payload)
+}
+
+// receiveMessageFromJS is a Go function exposed to JS for receiving messages from JS
+func receiveMessageFromJS(this js.Value, args []js.Value) interface{} {
+	if len(args) < 2 {
+		return nil
+	}
+	msgType := args[0].String()
+	payload := args[1].String()
+	// Handle different message types here
+	switch msgType {
+	case "consoleIn":
+		// For now, just echo input back to terminal
+		sendMessageToJS("consoleOut", payload)
+	case "diskRead":
+		// Future: handle disk read
+	case "diskWrite":
+		// Future: handle disk write
+	}
+	return nil
+}
+
+func generateTestPattern() string {
+	// Generate an 80x25 test pattern with header and left row digits
+	pattern := " "
+	for col := 0; col < 79; col++ {
+		pattern += string('0' + (col % 10))
+	}
+	pattern += "\r\n"
+	for row := 1; row < 25; row++ {
+		pattern += string('0' + (row % 10))
+		for col := 1; col < 80; col++ {
+			pattern += string('A' + ((col - 1) % 26))
+		}
+		pattern += "\r\n"
+	}
+	return pattern
+}
+
 func main() {
-	fmt.Println("Hello world!")
+	// Register Go function for JS to call
+	js.Global().Set("retrojs_sendToGo", js.FuncOf(receiveMessageFromJS))
+
+	// On startup, send test pattern to JS for terminal output
+	testPattern := generateTestPattern()
+	sendMessageToJS("consoleOut", testPattern)
+
+	// Prevent Go from exiting
+	select {}
 }

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -41,7 +41,9 @@ func generateTestPattern() string {
 		for col := 1; col < 80; col++ {
 			pattern += string('A' + ((col - 1) % 26))
 		}
-		pattern += "\r\n"
+		if row < 24 {
+			pattern += "\r\n"
+		}
 	}
 	return pattern
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@fontsource/vt323": "^5.2.7",
-        "@xterm/xterm": "^6.0.0"
+        "@xterm/addon-web-fonts": "^0.1.0",
+        "@xterm/xterm": "^6.1.0-beta.91"
       },
       "devDependencies": {
         "vite": "^7.3.0"
@@ -824,10 +825,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@xterm/addon-web-fonts": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-fonts/-/addon-web-fonts-0.1.0.tgz",
+      "integrity": "sha512-6plTfWFE1aBnZ0rcFu7Zpzb+rYFBYin7A1g2GP/KP6sqvcH8CRHWXTyutj/1lYMMlRE7OpwOxlRlzQHH8eU18Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^6.1.0-beta.86"
+      }
+    },
     "node_modules/@xterm/xterm": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
-      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "version": "6.1.0-beta.91",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.1.0-beta.91.tgz",
+      "integrity": "sha512-sXd6uKhMB3cycSyW/I8eVGglZ9+rGDLDTtm9fkiXDPcA1N/oMiR0iUKGstv2VOCT/40af3+//kYgl8IwOqPbxw==",
       "license": "MIT",
       "workspaces": [
         "addons/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@fontsource/vt323": "^5.2.7",
         "@xterm/xterm": "^6.0.0"
       },
       "devDependencies": {
@@ -455,6 +456,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource/vt323": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/vt323/-/vt323-5.2.7.tgz",
+      "integrity": "sha512-8JTMM23vMhQxin9Cn/ijty8cNwXW4INrln0VAJ2227Rz0CVfkzM3qr3l/CqudZJ6BXCnbCGUTdf2ym3cTNex8A==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "homepage": "https://github.com/bbgott/retrojs#readme",
   "dependencies": {
     "@fontsource/vt323": "^5.2.7",
-    "@xterm/xterm": "^6.0.0"
+    "@xterm/addon-web-fonts": "^0.1.0",
+    "@xterm/xterm": "^6.1.0-beta.91"
   },
   "devDependencies": {
     "vite": "^7.3.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/bbgott/retrojs#readme",
   "dependencies": {
+    "@fontsource/vt323": "^5.2.7",
     "@xterm/xterm": "^6.0.0"
   },
   "devDependencies": {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,3 +1,13 @@
+.terminal, .terminal .inner, #terminal, #terminal .xterm, #terminal .xterm * {
+    scrollbar-width: none !important;
+    -ms-overflow-style: none !important;
+}
+.terminal::-webkit-scrollbar, .terminal .inner::-webkit-scrollbar, #terminal::-webkit-scrollbar, #terminal .xterm::-webkit-scrollbar, #terminal .xterm *::-webkit-scrollbar {
+    width: 0 !important;
+    height: 0 !important;
+    display: none !important;
+    background: transparent !important;
+}
 body {
     background-color: #181a1b;
     /* Muted dark background for comfort */
@@ -14,7 +24,7 @@ body {
     overflow: hidden;
 }
 #terminal, #terminal .xterm, #terminal .xterm * {
-    font-family: 'VT323', monospace !important;
+    font-family: VT323, monospace !important;
     color: #39FF14 !important; /* Green phosphor */
 }
 .xterm-viewport.xterm-viewport {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,3 +1,7 @@
+body {
+    background-color: #181a1b;
+    /* Muted dark background for comfort */
+}
 .terminal {
     display:flex;
     justify-content:left;
@@ -6,22 +10,18 @@
 .terminal .inner {
     padding:10px 20px;
     border-radius:4px;
-    background-color:#2D2E2C
+    background-color:#2D2E2C;
+    overflow: hidden;
 }
 #terminal, #terminal .xterm, #terminal .xterm * {
     font-family: 'VT323', monospace !important;
     color: #39FF14 !important; /* Green phosphor */
 }
 .xterm-viewport.xterm-viewport {
-    scrollbar-width: thin;
+    scrollbar-width: none !important;
+    overflow: hidden !important;
 }
 .xterm-viewport::-webkit-scrollbar {
-    width: 10px;
-}
-.xterm-viewport::-webkit-scrollbar-track {
-    opacity: 0;
-}
-.xterm-viewport::-webkit-scrollbar-thumb {
-    min-height: 20px;
-    background-color: #ffffff20;
+    width: 0 !important;
+    display: none !important;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -2,7 +2,6 @@
 <head>
     <meta charset="utf-8"/>
     <link rel="stylesheet" href="css/main.css" />
-    <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
     <script type="module" src="/main.js"></script>
     <script src="wasm_exec.js"></script>
     <script>

--- a/static/index.html
+++ b/static/index.html
@@ -4,12 +4,6 @@
     <link rel="stylesheet" href="css/main.css" />
     <script type="module" src="/main.js"></script>
     <script src="wasm_exec.js"></script>
-    <script>
-        const go = new Go();
-        WebAssembly.instantiateStreaming(fetch("main.wasm"), go.importObject).then((result) => {
-            go.run(result.instance);
-        });
-    </script>
     <title>RetroJS</title>
 </head>
 <body>

--- a/static/main.js
+++ b/static/main.js
@@ -1,13 +1,27 @@
-import "@fontsource/vt323";
 import { Terminal } from '@xterm/xterm';
+import { WebFontsAddon, loadFonts } from '@xterm/addon-web-fonts';
 import '@xterm/xterm/css/xterm.css';
+import '@fontsource/vt323';
 
+window.retrojs = {
+  term: null,
+  terminalWrite: function (text) {
+    if (this.term) {
+      this.term.write(text);
+    }
+  },
+  sendToGo: function (msgType, payload) {
+    if (typeof window.retrojs_sendToGo === 'function') {
+      window.retrojs_sendToGo(msgType, payload);
+    }
+  }
+};
 
 // --- JS<->Go message passing framework ---
-window.retrojs_receiveFromGo = function(msgType, payload) {
+window.retrojs_receiveFromGo = function (msgType, payload) {
   switch (msgType) {
     case 'consoleOut':
-      retrojs.terminalWrite(payload);
+      window.retrojs.terminalWrite(payload);
       break;
     case 'diskRead':
       // Future: handle disk read
@@ -20,35 +34,49 @@ window.retrojs_receiveFromGo = function(msgType, payload) {
   }
 };
 
-window.retrojs = {
-  term: null,
-  terminalWrite: function(text) {
-    if (this.term) {
-      this.term.write(text);
-    }
-  },
-  sendToGo: function(msgType, payload) {
-    if (typeof window.retrojs_sendToGo === 'function') {
-      window.retrojs_sendToGo(msgType, payload);
-    }
+window.addEventListener('DOMContentLoaded', async () => {
+  // 1. Load VT323 font
+  let fontFamily = 'VT323, monospace';
+  try {
+    await loadFonts(['VT323']);
+  } catch (e) {
+    fontFamily = 'monospace';
   }
-};
 
-window.addEventListener('DOMContentLoaded', () => {
+  // 2. Setup xterm.js
   const term = new Terminal({
     cols: 80,
     rows: 25,
-    cursorBlink: true
+    cursorBlink: true,
+    fontFamily,
+    scrollback: 0
   });
+  const webFontsAddon = new WebFontsAddon();
+  term.loadAddon(webFontsAddon);
   window.retrojs.term = term;
   const container = document.querySelector('.terminal .inner');
   if (container) {
     term.open(container);
-    // Handle user input and send to Go
     term.onData(data => {
       window.retrojs.sendToGo('consoleIn', data);
     });
   } else {
     console.error('Terminal container element not found!');
+  }
+
+  // 3. Start Go WASM after everything is ready
+  if (typeof Go !== 'undefined') {
+    const go = new Go();
+    if ('instantiateStreaming' in WebAssembly) {
+      const result = await WebAssembly.instantiateStreaming(fetch('main.wasm'), go.importObject);
+      go.run(result.instance);
+    } else {
+      const response = await fetch('main.wasm');
+      const bytes = await response.arrayBuffer();
+      const result = await WebAssembly.instantiate(bytes, go.importObject);
+      go.run(result.instance);
+    }
+  } else {
+    console.error('Go WASM runtime (wasm_exec.js) not loaded!');
   }
 });

--- a/static/main.js
+++ b/static/main.js
@@ -49,6 +49,11 @@ window.addEventListener('DOMContentLoaded', async () => {
     rows: 25,
     cursorBlink: true,
     fontFamily,
+    theme: {
+      foreground: '#39FF14',
+      cursor: '#39FF14',
+      cursorAccent: '#181a1b'
+    },
     scrollback: 0
   });
   const webFontsAddon = new WebFontsAddon();

--- a/static/main.js
+++ b/static/main.js
@@ -1,31 +1,52 @@
 import { Terminal } from '@xterm/xterm';
 import '@xterm/xterm/css/xterm.css';
 
+
+// --- JS<->Go message passing framework ---
+window.retrojs_receiveFromGo = function(msgType, payload) {
+  switch (msgType) {
+    case 'consoleOut':
+      retrojs.terminalWrite(payload);
+      break;
+    case 'diskRead':
+      // Future: handle disk read
+      break;
+    case 'diskWrite':
+      // Future: handle disk write
+      break;
+    default:
+      console.warn('Unknown message from Go:', msgType, payload);
+  }
+};
+
+window.retrojs = {
+  term: null,
+  terminalWrite: function(text) {
+    if (this.term) {
+      this.term.write(text);
+    }
+  },
+  sendToGo: function(msgType, payload) {
+    if (typeof window.retrojs_sendToGo === 'function') {
+      window.retrojs_sendToGo(msgType, payload);
+    }
+  }
+};
+
 window.addEventListener('DOMContentLoaded', () => {
   const term = new Terminal({
     cols: 80,
     rows: 25,
     cursorBlink: true
   });
+  window.retrojs.term = term;
   const container = document.querySelector('.terminal .inner');
   if (container) {
     term.open(container);
-
-    // Header row: 0-9 repeated across 80 columns (first cell blank for row labels)
-    let header = ' ';
-    for (let col = 0; col < 79; col++) {
-      header += (col % 10).toString();
-    }
-    term.write(header + '\r\n');
-
-    // Fill the terminal with a visible pattern and left row numbers
-    for (let row = 1; row < 25; row++) {
-      let line = (row % 10).toString();
-      for (let col = 1; col < 80; col++) {
-        line += String.fromCharCode(65 + ((col - 1) % 26)); // A-Z
-      }
-      term.write(line + '\r\n');
-    }
+    // Handle user input and send to Go
+    term.onData(data => {
+      window.retrojs.sendToGo('consoleIn', data);
+    });
   } else {
     console.error('Terminal container element not found!');
   }

--- a/static/main.js
+++ b/static/main.js
@@ -1,3 +1,4 @@
+import "@fontsource/vt323";
 import { Terminal } from '@xterm/xterm';
 import '@xterm/xterm/css/xterm.css';
 


### PR DESCRIPTION
This pull request introduces a new message-passing framework between Go (WASM) and JavaScript, refactors terminal rendering to be Go-driven, and improves the terminal's appearance and font loading for a more authentic retro experience. The Go code now generates and sends the terminal test pattern, while JavaScript handles rendering and user input, enabling future extensibility for disk operations and other features.

**Go/JS communication and terminal rendering:**

- Introduced a message-passing framework between Go and JavaScript using `retrojs_sendToGo` and `retrojs_receiveFromGo` for bi-directional communication, with support for message types like `consoleIn` and `consoleOut`. The Go code now generates the terminal test pattern and sends it to JS, which writes it to the terminal. [[1]](diffhunk://#diff-1a1e16bd11061b4892de841ee25801dd23676d371bc3c7619281801d9bdecdc0L4-R60) [[2]](diffhunk://#diff-acd2228669a20570c1c6bfe003b0b075ded45f1270f2dac8fda906c9583f4531R2-R85)

- Refactored JavaScript to handle terminal output exclusively via messages from Go, removing the previous direct pattern rendering logic from JS. User input in the terminal is now sent to Go through the message framework.

**Terminal appearance and font improvements:**

- Switched to using the locally bundled VT323 font via `@fontsource/vt323` and the xterm.js web fonts addon for improved retro authenticity and reliability, removing the Google Fonts dependency from `index.html`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L30-R32) [[2]](diffhunk://#diff-acd2228669a20570c1c6bfe003b0b075ded45f1270f2dac8fda906c9583f4531R2-R85) [[3]](diffhunk://#diff-3e8602c86d6cf04a5c74b954f9f957b652617102cf8f4b647fe46989f480861dL5-L13)

- Enhanced terminal CSS to hide scrollbars, set a dark background, and ensure consistent retro styling and font usage throughout the terminal interface. [[1]](diffhunk://#diff-7c6d9b791479470684ffe55c750a991e18239247dc75846ca2e688606e8e8887R1-R14) [[2]](diffhunk://#diff-7c6d9b791479470684ffe55c750a991e18239247dc75846ca2e688606e8e8887L9-R36)

**Dependency updates:**

- Updated dependencies in `package.json` to include `@fontsource/vt323` and `@xterm/addon-web-fonts`, and bumped `@xterm/xterm` to a newer beta version for improved font support.